### PR TITLE
Add rest of JDBC connectors excluding redshift

### DIFF
--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveCompositeHandler.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.cloudera;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connector.lambda.connection.HiveEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -33,6 +33,6 @@ public class HiveCompositeHandler
 {
     public HiveCompositeHandler()
     {
-        super(new HiveMetadataHandler(GlueConnectionUtils.getGlueConnection()), new HiveRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new HiveMetadataHandler(new HiveEnvironmentProperties().createEnvironment()), new HiveRecordHandler(new HiveEnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveCompositeHandler.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.cloudera;
 
-import com.amazonaws.athena.connector.lambda.connection.HiveEnvironmentProperties;
+import com.amazonaws.athena.connector.lambda.connection.ClouderaHiveEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -33,6 +33,6 @@ public class HiveCompositeHandler
 {
     public HiveCompositeHandler()
     {
-        super(new HiveMetadataHandler(new HiveEnvironmentProperties().createEnvironment()), new HiveRecordHandler(new HiveEnvironmentProperties().createEnvironment()));
+        super(new HiveMetadataHandler(new ClouderaHiveEnvironmentProperties().createEnvironment()), new HiveRecordHandler(new ClouderaHiveEnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaCompositeHandler.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaCompositeHandler.java
@@ -20,7 +20,7 @@
  */
 package com.amazonaws.athena.connectors.cloudera;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connector.lambda.connection.ImpalaEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -34,6 +34,7 @@ public class ImpalaCompositeHandler
 {
     public ImpalaCompositeHandler()
     {
-        super(new ImpalaMetadataHandler(GlueConnectionUtils.getGlueConnection()), new ImpalaRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new ImpalaMetadataHandler(new ImpalaEnvironmentProperties().createEnvironment()),
+                new ImpalaRecordHandler(new ImpalaEnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2CompositeHandler.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2CompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.datalakegen2;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connector.lambda.connection.DataLakeGen2EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -32,6 +32,6 @@ public class DataLakeGen2CompositeHandler extends CompositeHandler
 {
     public DataLakeGen2CompositeHandler()
     {
-        super(new DataLakeGen2MetadataHandler(GlueConnectionUtils.getGlueConnection()), new DataLakeGen2RecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new DataLakeGen2MetadataHandler(new DataLakeGen2EnvironmentProperties().createEnvironment()), new DataLakeGen2RecordHandler(new DataLakeGen2EnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400CompositeHandler.java
+++ b/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400CompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.db2as400;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connector.lambda.connection.Db2As400EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -32,6 +32,6 @@ public class Db2As400CompositeHandler extends CompositeHandler
 {
     public Db2As400CompositeHandler()
     {
-        super(new Db2As400MetadataHandler(GlueConnectionUtils.getGlueConnection()), new Db2As400RecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new Db2As400MetadataHandler(new Db2As400EnvironmentProperties().createEnvironment()), new Db2As400RecordHandler(new Db2As400EnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/ClouderaHiveEnvironmentProperties.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/ClouderaHiveEnvironmentProperties.java
@@ -21,7 +21,7 @@ package com.amazonaws.athena.connector.lambda.connection;
 
 import java.util.Map;
 
-public class HiveEnvironmentProperties extends JdbcEnvironmentProperties
+public class ClouderaHiveEnvironmentProperties extends JdbcEnvironmentProperties
 {
     private static final String SESSION_CONFS = "SESSION_CONFS";
     private static final String HIVE_CONFS = "HIVE_CONFS";

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/DataLakeGen2EnvironmentProperties.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/DataLakeGen2EnvironmentProperties.java
@@ -21,29 +21,11 @@ package com.amazonaws.athena.connector.lambda.connection;
 
 import java.util.Map;
 
-public class SqlServerEnvironmentProperties extends JdbcEnvironmentProperties
+public class DataLakeGen2EnvironmentProperties extends SqlServerEnvironmentProperties
 {
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {
-        return "sqlserver://jdbc:sqlserver://";
-    }
-
-    @Override
-    protected String getDatabase(Map<String, String> connectionProperties)
-    {
-        return ";databaseName=" + connectionProperties.get(DATABASE);
-    }
-
-    @Override
-    protected String getJdbcParametersSeparator()
-    {
-        return ";";
-    }
-
-    @Override
-    protected String getDelimiter()
-    {
-        return ";";
+        return "datalakegentwo://jdbc:sqlserver://";
     }
 }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/Db2As400EnvironmentProperties.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/Db2As400EnvironmentProperties.java
@@ -1,0 +1,49 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connector.lambda.connection;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Db2As400EnvironmentProperties extends EnvironmentProperties
+{
+    private static final String JDBC_PARAMS = "JDBC_PARAMS";
+    private static final String DEFAULT = "default";
+    @Override
+    public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
+    {
+        HashMap<String, String> environment = new HashMap<>();
+
+        // now construct jdbc string
+        String connectionString = "db2as400://jdbc:as400://" + connectionProperties.get("HOST")
+                + ";" + connectionProperties.getOrDefault(JDBC_PARAMS, "");
+
+        if (connectionProperties.containsKey(SECRET_NAME)) {
+            if (connectionProperties.containsKey(JDBC_PARAMS)) { // need to add delimiter
+                connectionString = connectionString + ";";
+            }
+            connectionString = connectionString + ":${" + connectionProperties.get(SECRET_NAME) + "}";
+        }
+
+        logger.debug("Constructed connection string: {}", connectionString);
+        environment.put(DEFAULT, connectionString);
+        return environment;
+    }
+}

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/Db2EnvironmentProperties.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/Db2EnvironmentProperties.java
@@ -21,24 +21,18 @@ package com.amazonaws.athena.connector.lambda.connection;
 
 import java.util.Map;
 
-public class SqlServerEnvironmentProperties extends JdbcEnvironmentProperties
+public class Db2EnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {
-        return "sqlserver://jdbc:sqlserver://";
+        return "dbtwo://jdbc:db2://";
     }
 
     @Override
     protected String getDatabase(Map<String, String> connectionProperties)
     {
-        return ";databaseName=" + connectionProperties.get(DATABASE);
-    }
-
-    @Override
-    protected String getJdbcParametersSeparator()
-    {
-        return ";";
+        return ":" + connectionProperties.get(DATABASE);
     }
 
     @Override

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/EnvironmentProperties.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/EnvironmentProperties.java
@@ -41,7 +41,7 @@ public class EnvironmentProperties
     protected static final String SECRET_NAME = "secret_name";
     protected static final String SPILL_KMS_KEY_ID = "spill_kms_key_id";
     protected static final String KMS_KEY_ID = "kms_key_id";
-    private static final Logger logger = LoggerFactory.getLogger(EnvironmentProperties.class);
+    protected static final Logger logger = LoggerFactory.getLogger(EnvironmentProperties.class);
 
     public Map<String, String> createEnvironment() throws RuntimeException
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/HiveEnvironmentProperties.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/HiveEnvironmentProperties.java
@@ -1,0 +1,64 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connector.lambda.connection;
+
+import java.util.Map;
+
+public class HiveEnvironmentProperties extends JdbcEnvironmentProperties
+{
+    private static final String SESSION_CONFS = "SESSION_CONFS";
+    private static final String HIVE_CONFS = "HIVE_CONFS";
+    private static final String HIVE_VARS = "HIVE_VARS";
+
+    @Override
+    protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
+    {
+        return "hive://jdbc:hive2://";
+    }
+
+    @Override
+    protected String getJdbcParameters(Map<String, String> connectionProperties)
+    {
+        String params = "?" + connectionProperties.getOrDefault(SESSION_CONFS, "");
+
+        if (connectionProperties.containsKey(HIVE_CONFS)) {
+            if (connectionProperties.containsKey(SESSION_CONFS)) {
+                params = params + ";";
+            }
+            params = params + connectionProperties.get(HIVE_CONFS);
+        }
+
+        if (connectionProperties.containsKey(HIVE_VARS)) {
+            if (connectionProperties.containsKey(HIVE_CONFS)) {
+                params = params + ";";
+            }
+            params = params + connectionProperties.get(HIVE_VARS);
+        }
+
+        if (connectionProperties.containsKey(SECRET_NAME)) {
+            if (connectionProperties.containsKey(HIVE_VARS)) { // need to add delimiter
+                params = params + ";";
+            }
+            params = params + "${" + connectionProperties.get(SECRET_NAME) + "}";
+        }
+
+        return params;
+    }
+}

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/HortonworksEnvironmentProperties.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/HortonworksEnvironmentProperties.java
@@ -1,0 +1,31 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connector.lambda.connection;
+
+import java.util.Map;
+
+public class HortonworksEnvironmentProperties extends JdbcEnvironmentProperties
+{
+    @Override
+    protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
+    {
+        return "hive://jdbc:hive2://";
+    }
+}

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/ImpalaEnvironmentProperties.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/ImpalaEnvironmentProperties.java
@@ -21,29 +21,11 @@ package com.amazonaws.athena.connector.lambda.connection;
 
 import java.util.Map;
 
-public class SqlServerEnvironmentProperties extends JdbcEnvironmentProperties
+public class ImpalaEnvironmentProperties extends SaphanaEnvironmentProperties
 {
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {
-        return "sqlserver://jdbc:sqlserver://";
-    }
-
-    @Override
-    protected String getDatabase(Map<String, String> connectionProperties)
-    {
-        return ";databaseName=" + connectionProperties.get(DATABASE);
-    }
-
-    @Override
-    protected String getJdbcParametersSeparator()
-    {
-        return ";";
-    }
-
-    @Override
-    protected String getDelimiter()
-    {
-        return ";";
+        return "impala://jdbc:impala://";
     }
 }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/JdbcEnvironmentProperties.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/JdbcEnvironmentProperties.java
@@ -35,28 +35,46 @@ public abstract class JdbcEnvironmentProperties extends EnvironmentProperties
 
         // now construct jdbc string
         String connectionString = getConnectionStringPrefix(connectionProperties) + connectionProperties.get("HOST")
-                + ":" + connectionProperties.get("PORT") + getConnectionStringSuffix(connectionProperties);
+                + ":" + connectionProperties.get("PORT") + getDatabase(connectionProperties) + getJdbcParameters(connectionProperties);
 
+        logger.debug("Constructed connection string: {}", connectionString);
         environment.put(DEFAULT, connectionString);
         return environment;
     }
 
     protected abstract String getConnectionStringPrefix(Map<String, String> connectionProperties);
 
-    protected String getConnectionStringSuffix(Map<String, String> connectionProperties)
+    protected String getDatabase(Map<String, String> connectionProperties)
     {
-        String suffix = "/" + connectionProperties.get(DATABASE) + "?"
-                + connectionProperties.getOrDefault(JDBC_PARAMS, "");
+        return getDatabaseSeparator() + connectionProperties.get(DATABASE);
+    }
+
+    protected String getJdbcParameters(Map<String, String> connectionProperties)
+    {
+        String params = getJdbcParametersSeparator() + connectionProperties.getOrDefault(JDBC_PARAMS, "");
 
         if (connectionProperties.containsKey(SECRET_NAME)) {
             if (connectionProperties.containsKey(JDBC_PARAMS)) { // need to add delimiter
-                suffix = suffix + "&${" + connectionProperties.get(SECRET_NAME) + "}";
+                params = params + getDelimiter();
             }
-            else {
-                suffix = suffix + "${" + connectionProperties.get(SECRET_NAME) + "}";
-            }
+            params = params + "${" + connectionProperties.get(SECRET_NAME) + "}";
         }
 
-        return suffix;
+        return params;
+    }
+
+    protected String getDatabaseSeparator()
+    {
+        return "/";
+    }
+
+    protected String getJdbcParametersSeparator()
+    {
+        return "?";
+    }
+
+    protected String getDelimiter()
+    {
+        return "&";
     }
 }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/OracleEnvironmentProperties.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/OracleEnvironmentProperties.java
@@ -30,13 +30,20 @@ public class OracleEnvironmentProperties extends JdbcEnvironmentProperties
         if (connectionProperties.containsKey(SECRET_NAME)) {
             prefix = prefix + "${" + connectionProperties.get(SECRET_NAME) + "}";
         }
+        prefix = prefix + "@//";
 
         return prefix;
     }
 
     @Override
-    protected String getConnectionStringSuffix(Map<String, String> connectionProperties)
+    protected String getDatabase(Map<String, String> connectionProperties)
     {
         return "/" + connectionProperties.get(DATABASE);
+    }
+
+    @Override
+    protected String getJdbcParameters(Map<String, String> connectionProperties)
+    {
+        return "";
     }
 }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/SaphanaEnvironmentProperties.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/SaphanaEnvironmentProperties.java
@@ -21,29 +21,17 @@ package com.amazonaws.athena.connector.lambda.connection;
 
 import java.util.Map;
 
-public class SqlServerEnvironmentProperties extends JdbcEnvironmentProperties
+public class SaphanaEnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {
-        return "sqlserver://jdbc:sqlserver://";
+        return "saphana://jdbc:sap://";
     }
 
     @Override
     protected String getDatabase(Map<String, String> connectionProperties)
     {
-        return ";databaseName=" + connectionProperties.get(DATABASE);
-    }
-
-    @Override
-    protected String getJdbcParametersSeparator()
-    {
-        return ";";
-    }
-
-    @Override
-    protected String getDelimiter()
-    {
-        return ";";
+        return "/";
     }
 }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/SnowflakeEnvironmentProperties.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/SnowflakeEnvironmentProperties.java
@@ -21,29 +21,26 @@ package com.amazonaws.athena.connector.lambda.connection;
 
 import java.util.Map;
 
-public class SqlServerEnvironmentProperties extends JdbcEnvironmentProperties
+public class SnowflakeEnvironmentProperties extends JdbcEnvironmentProperties
 {
+    private static final String WAREHOUSE = "WAREHOUSE";
+    private static final String SCHEMA = "SCHEMA";
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {
-        return "sqlserver://jdbc:sqlserver://";
+        return "snowflake://jdbc:snowflake://";
     }
 
     @Override
     protected String getDatabase(Map<String, String> connectionProperties)
     {
-        return ";databaseName=" + connectionProperties.get(DATABASE);
-    }
+        if (!connectionProperties.containsKey(SCHEMA)) {
+            logger.debug("No schema specified in connection string");
+        }
 
-    @Override
-    protected String getJdbcParametersSeparator()
-    {
-        return ";";
-    }
-
-    @Override
-    protected String getDelimiter()
-    {
-        return ";";
+        String databaseString = "/?warehouse=" + connectionProperties.get(WAREHOUSE)
+                + "&db=" + connectionProperties.get(DATABASE)
+                + "&schema=" + connectionProperties.get(SCHEMA);
+        return databaseString;
     }
 }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/TeradataEnvironmentProperties.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/TeradataEnvironmentProperties.java
@@ -21,29 +21,23 @@ package com.amazonaws.athena.connector.lambda.connection;
 
 import java.util.Map;
 
-public class SqlServerEnvironmentProperties extends JdbcEnvironmentProperties
+public class TeradataEnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {
-        return "sqlserver://jdbc:sqlserver://";
+        return "teradata://jdbc:teradata://";
     }
 
     @Override
     protected String getDatabase(Map<String, String> connectionProperties)
     {
-        return ";databaseName=" + connectionProperties.get(DATABASE);
+        return "/TMODE=ANSI,CHARSET=UTF8,DATABASE=" + connectionProperties.get(DATABASE);
     }
 
     @Override
     protected String getJdbcParametersSeparator()
     {
-        return ";";
-    }
-
-    @Override
-    protected String getDelimiter()
-    {
-        return ";";
+        return ",";
     }
 }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/VerticaEnvironmentProperties.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/VerticaEnvironmentProperties.java
@@ -21,29 +21,11 @@ package com.amazonaws.athena.connector.lambda.connection;
 
 import java.util.Map;
 
-public class SqlServerEnvironmentProperties extends JdbcEnvironmentProperties
+public class VerticaEnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {
-        return "sqlserver://jdbc:sqlserver://";
-    }
-
-    @Override
-    protected String getDatabase(Map<String, String> connectionProperties)
-    {
-        return ";databaseName=" + connectionProperties.get(DATABASE);
-    }
-
-    @Override
-    protected String getJdbcParametersSeparator()
-    {
-        return ";";
-    }
-
-    @Override
-    protected String getDelimiter()
-    {
-        return ";";
+        return "vertica://jdbc:vertica://";
     }
 }

--- a/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HiveCompositeHandler.java
+++ b/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HiveCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.hortonworks;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connector.lambda.connection.HiveEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -33,6 +33,6 @@ public class HiveCompositeHandler
 {
     public HiveCompositeHandler()
     {
-        super(new HiveMetadataHandler(GlueConnectionUtils.getGlueConnection()), new HiveRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new HiveMetadataHandler(new HiveEnvironmentProperties().createEnvironment()), new HiveRecordHandler(new HiveEnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HiveCompositeHandler.java
+++ b/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HiveCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.hortonworks;
 
-import com.amazonaws.athena.connector.lambda.connection.HiveEnvironmentProperties;
+import com.amazonaws.athena.connector.lambda.connection.HortonworksEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -33,6 +33,6 @@ public class HiveCompositeHandler
 {
     public HiveCompositeHandler()
     {
-        super(new HiveMetadataHandler(new HiveEnvironmentProperties().createEnvironment()), new HiveRecordHandler(new HiveEnvironmentProperties().createEnvironment()));
+        super(new HiveMetadataHandler(new HortonworksEnvironmentProperties().createEnvironment()), new HiveRecordHandler(new HortonworksEnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaCompositeHandler.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaCompositeHandler.java
@@ -22,7 +22,7 @@
 
 package com.amazonaws.athena.connectors.saphana;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connector.lambda.connection.SaphanaEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -36,6 +36,6 @@ public class SaphanaCompositeHandler
 {
     public SaphanaCompositeHandler()
     {
-        super(new SaphanaMetadataHandler(GlueConnectionUtils.getGlueConnection()), new SaphanaRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new SaphanaMetadataHandler(new SaphanaEnvironmentProperties().createEnvironment()), new SaphanaRecordHandler(new SaphanaEnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeCompositeHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeCompositeHandler.java
@@ -22,7 +22,7 @@
 
 package com.amazonaws.athena.connectors.snowflake;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connector.lambda.connection.SnowflakeEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -36,6 +36,6 @@ public class SnowflakeCompositeHandler
 {
     public SnowflakeCompositeHandler()
     {
-        super(new SnowflakeMetadataHandler(GlueConnectionUtils.getGlueConnection()), new SnowflakeRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new SnowflakeMetadataHandler(new SnowflakeEnvironmentProperties().createEnvironment()), new SnowflakeRecordHandler(new SnowflakeEnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaCompositeHandler.java
+++ b/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.vertica;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connector.lambda.connection.VerticaEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 import java.io.IOException;
@@ -39,7 +39,7 @@ public class VerticaCompositeHandler
 {
     public VerticaCompositeHandler() throws CertificateEncodingException, IOException, NoSuchAlgorithmException, KeyStoreException
     {
-        super(new VerticaMetadataHandler(GlueConnectionUtils.getGlueConnection()), new VerticaRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new VerticaMetadataHandler(new VerticaEnvironmentProperties().createEnvironment()), new VerticaRecordHandler(new VerticaEnvironmentProperties().createEnvironment()));
         installCaCertificate();
         setupNativeEnvironmentVariables();
     }


### PR DESCRIPTION
Implement environment properties for rest of JDBC.

Read in properties from glue connection v2 objects. Since JDBC connections do not have 'default' defined, we construct the jdbc string from HOST, PORT, DATABASE, JDBC_PARAMS. 