### PR TITLE
Implement EnvironmentProperties for remaining non-jdbc connectors

### DIFF
--- a/athena-aws-cmdb/src/main/java/com/amazonaws/athena/connectors/aws/cmdb/AwsCmdbCompositeHandler.java
+++ b/athena-aws-cmdb/src/main/java/com/amazonaws/athena/connectors/aws/cmdb/AwsCmdbCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.aws.cmdb;
 
-import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**

--- a/athena-aws-cmdb/src/main/java/com/amazonaws/athena/connectors/aws/cmdb/AwsCmdbCompositeHandler.java
+++ b/athena-aws-cmdb/src/main/java/com/amazonaws/athena/connectors/aws/cmdb/AwsCmdbCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.aws.cmdb;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -31,6 +31,6 @@ public class AwsCmdbCompositeHandler
 {
     public AwsCmdbCompositeHandler()
     {
-        super(new AwsCmdbMetadataHandler(GlueConnectionUtils.getGlueConnection()), new AwsCmdbRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new AwsCmdbMetadataHandler(new EnvironmentProperties().createEnvironment()), new AwsCmdbRecordHandler(new EnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/ClouderaHiveEnvironmentProperties.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/ClouderaHiveEnvironmentProperties.java
@@ -23,12 +23,13 @@ import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.HIVE_CONFS;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.HIVE_VARS;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.SECRET_NAME;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.SESSION_CONFS;
+
 public class ClouderaHiveEnvironmentProperties extends JdbcEnvironmentProperties
 {
-    private static final String SESSION_CONFS = "SESSION_CONFS";
-    private static final String HIVE_CONFS = "HIVE_CONFS";
-    private static final String HIVE_VARS = "HIVE_VARS";
-
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {

--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/ClouderaHiveEnvironmentProperties.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/ClouderaHiveEnvironmentProperties.java
@@ -17,7 +17,9 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.connection;
+package com.amazonaws.athena.connectors.cloudera;
+
+import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 

--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveCompositeHandler.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveCompositeHandler.java
@@ -19,7 +19,6 @@
  */
 package com.amazonaws.athena.connectors.cloudera;
 
-import com.amazonaws.athena.connector.lambda.connection.ClouderaHiveEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**

--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaCompositeHandler.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaCompositeHandler.java
@@ -20,7 +20,6 @@
  */
 package com.amazonaws.athena.connectors.cloudera;
 
-import com.amazonaws.athena.connector.lambda.connection.ImpalaEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**

--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaEnvironmentProperties.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaEnvironmentProperties.java
@@ -31,6 +31,7 @@ public class ImpalaEnvironmentProperties extends JdbcEnvironmentProperties
         return "impala://jdbc:impala://";
     }
 
+    @Override
     protected String getDatabase(Map<String, String> connectionProperties)
     {
         return "/";

--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaEnvironmentProperties.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaEnvironmentProperties.java
@@ -17,19 +17,20 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.connection;
+package com.amazonaws.athena.connectors.cloudera;
+
+import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 
-public class SaphanaEnvironmentProperties extends JdbcEnvironmentProperties
+public class ImpalaEnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {
-        return "saphana://jdbc:sap://";
+        return "impala://jdbc:impala://";
     }
 
-    @Override
     protected String getDatabase(Map<String, String> connectionProperties)
     {
         return "/";

--- a/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsCompositeHandler.java
+++ b/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.cloudwatch.metrics;
 
-import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**

--- a/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsCompositeHandler.java
+++ b/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.cloudwatch.metrics;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -31,6 +31,6 @@ public class MetricsCompositeHandler
 {
     public MetricsCompositeHandler()
     {
-        super(new MetricsMetadataHandler(GlueConnectionUtils.getGlueConnection()), new MetricsRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new MetricsMetadataHandler(new EnvironmentProperties().createEnvironment()), new MetricsRecordHandler(new EnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchCompositeHandler.java
+++ b/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.cloudwatch;
 
-import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**

--- a/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchCompositeHandler.java
+++ b/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.cloudwatch;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -31,6 +31,6 @@ public class CloudwatchCompositeHandler
 {
     public CloudwatchCompositeHandler()
     {
-        super(new CloudwatchMetadataHandler(GlueConnectionUtils.getGlueConnection()), new CloudwatchRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new CloudwatchMetadataHandler(new EnvironmentProperties().createEnvironment()), new CloudwatchRecordHandler(new EnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2CompositeHandler.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2CompositeHandler.java
@@ -19,7 +19,6 @@
  */
 package com.amazonaws.athena.connectors.datalakegen2;
 
-import com.amazonaws.athena.connector.lambda.connection.DataLakeGen2EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**

--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2EnvironmentProperties.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2EnvironmentProperties.java
@@ -23,6 +23,8 @@ import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DATABASE;
+
 public class DataLakeGen2EnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override

--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2EnvironmentProperties.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2EnvironmentProperties.java
@@ -17,15 +17,35 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.connection;
+package com.amazonaws.athena.connectors.datalakegen2;
+
+import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 
-public class VerticaEnvironmentProperties extends JdbcEnvironmentProperties
+public class DataLakeGen2EnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {
-        return "vertica://jdbc:vertica://";
+        return "datalakegentwo://jdbc:sqlserver://";
+    }
+
+    @Override
+    protected String getDatabase(Map<String, String> connectionProperties)
+    {
+        return ";databaseName=" + connectionProperties.get(DATABASE);
+    }
+
+    @Override
+    protected String getJdbcParametersSeparator()
+    {
+        return ";";
+    }
+
+    @Override
+    protected String getDelimiter()
+    {
+        return ";";
     }
 }

--- a/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400CompositeHandler.java
+++ b/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400CompositeHandler.java
@@ -19,7 +19,6 @@
  */
 package com.amazonaws.athena.connectors.db2as400;
 
-import com.amazonaws.athena.connector.lambda.connection.Db2As400EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**

--- a/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400EnvironmentProperties.java
+++ b/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400EnvironmentProperties.java
@@ -19,22 +19,25 @@
  */
 package com.amazonaws.athena.connectors.db2as400;
 
-import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentProperties;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DEFAULT;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.HOST;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.JDBC_PARAMS;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.SECRET_NAME;
+
 public class Db2As400EnvironmentProperties extends EnvironmentProperties
 {
-    private static final String JDBC_PARAMS = "JDBC_PARAMS";
-    private static final String DEFAULT = "default";
     @Override
     public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
     {
         HashMap<String, String> environment = new HashMap<>();
 
         // now construct jdbc string
-        String connectionString = "db2as400://jdbc:as400://" + connectionProperties.get("HOST")
+        String connectionString = "db2as400://jdbc:as400://" + connectionProperties.get(HOST)
                 + ";" + connectionProperties.getOrDefault(JDBC_PARAMS, "");
 
         if (connectionProperties.containsKey(SECRET_NAME)) {

--- a/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400EnvironmentProperties.java
+++ b/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400EnvironmentProperties.java
@@ -17,7 +17,9 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.connection;
+package com.amazonaws.athena.connectors.db2as400;
+
+import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2CompositeHandler.java
+++ b/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2CompositeHandler.java
@@ -19,7 +19,6 @@
  */
 package com.amazonaws.athena.connectors.db2;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -32,6 +31,6 @@ public class Db2CompositeHandler extends CompositeHandler
 {
     public Db2CompositeHandler()
     {
-        super(new Db2MetadataHandler(GlueConnectionUtils.getGlueConnection()), new Db2RecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new Db2MetadataHandler(new Db2EnvironmentProperties().createEnvironment()), new Db2RecordHandler(new Db2EnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2EnvironmentProperties.java
+++ b/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2EnvironmentProperties.java
@@ -23,6 +23,8 @@ import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DATABASE;
+
 public class Db2EnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override

--- a/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2EnvironmentProperties.java
+++ b/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2EnvironmentProperties.java
@@ -17,15 +17,29 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.connection;
+package com.amazonaws.athena.connectors.db2;
+
+import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 
-public class ImpalaEnvironmentProperties extends SaphanaEnvironmentProperties
+public class Db2EnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {
-        return "impala://jdbc:impala://";
+        return "dbtwo://jdbc:db2://";
+    }
+
+    @Override
+    protected String getDatabase(Map<String, String> connectionProperties)
+    {
+        return ":" + connectionProperties.get(DATABASE);
+    }
+
+    @Override
+    protected String getDelimiter()
+    {
+        return ";";
     }
 }

--- a/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBCompositeHandler.java
+++ b/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBCompositeHandler.java
@@ -31,6 +31,6 @@ public class DocDBCompositeHandler
 {
     public DocDBCompositeHandler()
     {
-        super(new DocDBMetadataHandler(new EnvironmentProperties().createEnvironment()), new DocDBRecordHandler(new EnvironmentProperties().createEnvironment()));
+        super(new DocDBMetadataHandler(new DocDBEnvironmentProperties().createEnvironment()), new DocDBRecordHandler(new DocDBEnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBCompositeHandler.java
+++ b/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBCompositeHandler.java
@@ -19,7 +19,6 @@
  */
 package com.amazonaws.athena.connectors.docdb;
 
-import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**

--- a/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBCompositeHandler.java
+++ b/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.docdb;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -31,6 +31,6 @@ public class DocDBCompositeHandler
 {
     public DocDBCompositeHandler()
     {
-        super(new DocDBMetadataHandler(GlueConnectionUtils.getGlueConnection()), new DocDBRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new DocDBMetadataHandler(new EnvironmentProperties().createEnvironment()), new DocDBRecordHandler(new EnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBEnvironmentProperties.java
+++ b/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBEnvironmentProperties.java
@@ -19,24 +19,27 @@
  */
 package com.amazonaws.athena.connectors.docdb;
 
-import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentProperties;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DEFAULT_DOCDB;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.HOST;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.JDBC_PARAMS;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.PORT;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.SECRET_NAME;
+
 public class DocDBEnvironmentProperties extends EnvironmentProperties
 {
-    private static final String JDBC_PARAMS = "JDBC_PARAMS";
-    private static final String DEFAULT_DOCDB = "default_docdb";
-
     @Override
     public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
     {
         Map<String, String> environment = new HashMap<>();
 
         String connectionString = "mongodb://${" + connectionProperties.get(SECRET_NAME) + "}@"
-                + connectionProperties.get("HOST") + connectionProperties.get("PORT") + "/?"
-                + connectionProperties.getOrDefault("JDBC_PARAMS", "");
+                + connectionProperties.get(HOST) + connectionProperties.get(PORT) + "/?"
+                + connectionProperties.getOrDefault(JDBC_PARAMS, "");
         environment.put(DEFAULT_DOCDB, connectionString);
         return environment;
     }

--- a/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBEnvironmentProperties.java
+++ b/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBEnvironmentProperties.java
@@ -28,6 +28,7 @@ public class DocDBEnvironmentProperties extends EnvironmentProperties
 {
     private static final String JDBC_PARAMS = "JDBC_PARAMS";
     private static final String DEFAULT_DOCDB = "default_docdb";
+
     @Override
     public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
     {

--- a/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBEnvironmentProperties.java
+++ b/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBEnvironmentProperties.java
@@ -1,0 +1,42 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.docdb;
+
+import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DocDBEnvironmentProperties extends EnvironmentProperties
+{
+    private static final String JDBC_PARAMS = "JDBC_PARAMS";
+    private static final String DEFAULT_DOCDB = "default_docdb";
+    @Override
+    public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
+    {
+        Map<String, String> environment = new HashMap<>();
+
+        String connectionString = "mongodb://${" + connectionProperties.get(SECRET_NAME) + "}@"
+                + connectionProperties.get("HOST") + connectionProperties.get("PORT") + "/?"
+                + connectionProperties.getOrDefault("JDBC_PARAMS", "");
+        environment.put(DEFAULT_DOCDB, connectionString);
+        return environment;
+    }
+}

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBCompositeHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.dynamodb;
 
-import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBCompositeHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.dynamodb;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -31,6 +31,6 @@ public class DynamoDBCompositeHandler
 {
     public DynamoDBCompositeHandler()
     {
-        super(new DynamoDBMetadataHandler(GlueConnectionUtils.getGlueConnection()), new DynamoDBRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new DynamoDBMetadataHandler(new EnvironmentProperties().createEnvironment()), new DynamoDBRecordHandler(new EnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchCompositeHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.elasticsearch;
 
-import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**

--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchCompositeHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.elasticsearch;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -31,6 +31,6 @@ public class ElasticsearchCompositeHandler
 {
     public ElasticsearchCompositeHandler()
     {
-        super(new ElasticsearchMetadataHandler(GlueConnectionUtils.getGlueConnection()), new ElasticsearchRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new ElasticsearchMetadataHandler(new EnvironmentProperties().createEnvironment()), new ElasticsearchRecordHandler(new EnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>glue</artifactId>
-            <version>${aws-sdk-v2.version}</version>
+            <version>9.9.9</version>
             <exclusions>
                 <exclusion>
                     <groupId>software.amazon.awssdk</groupId>

--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>glue</artifactId>
-            <version>9.9.9</version>
+            <version>${aws-sdk-v2.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>software.amazon.awssdk</groupId>

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/EnvironmentProperties.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/EnvironmentProperties.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.connection;
+package com.amazonaws.athena.connector.lambda;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/EnvironmentConstants.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/EnvironmentConstants.java
@@ -1,0 +1,54 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connector.lambda.connection;
+
+public final class EnvironmentConstants
+{
+    private EnvironmentConstants() {}
+
+    public static final int CONNECT_TIMEOUT = 250;
+
+    // Lambda environment variable keys
+    public static final String DEFAULT_GLUE_CONNECTION = "glue_connection";
+    public static final String SECRET_NAME = "secret_name";
+    public static final String SPILL_KMS_KEY_ID = "spill_kms_key_id";
+    public static final String KMS_KEY_ID = "kms_key_id";
+    public static final String DEFAULT = "default";
+    public static final String DEFAULT_DOCDB = "default_docdb";
+    public static final String DEFAULT_HBASE = "default_hbase";
+
+    // glue connection property names
+    public static final String HOST = "HOST";
+    public static final String PORT = "PORT";
+    public static final String JDBC_PARAMS = "JDBC_PARAMS";
+    public static final String DATABASE = "DATABASE";
+    public static final String SESSION_CONFS = "SESSION_CONFS";
+    public static final String HIVE_CONFS = "HIVE_CONFS";
+    public static final String HIVE_VARS = "HIVE_VARS";
+    public static final String WAREHOUSE = "WAREHOUSE";
+    public static final String SCHEMA = "SCHEMA";
+    public static final String PROJECT_ID = "PROJECT_ID";
+    public static final String CLUSTER_RES_ID = "CLUSTER_RESOURCE_ID";
+    public static final String GRAPH_TYPE = "GRAPH_TYPE";
+    public static final String HBASE_PORT = "HBASE_PORT";
+    public static final String ZOOKEEPER_PORT = "ZOOKEEPER_PORT";
+    public static final String CUSTOM_AUTH_TYPE = "CUSTOM_AUTH_TYPE";
+    public static final String GLUE_CERTIFICATES_S3_REFERENCE = "CERTIFICATE_S3_REFERENCE";
+}

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/EnvironmentProperties.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/EnvironmentProperties.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda;
+package com.amazonaws.athena.connector.lambda.connection;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -34,13 +34,14 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.CONNECT_TIMEOUT;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DEFAULT_GLUE_CONNECTION;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.KMS_KEY_ID;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.SECRET_NAME;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.SPILL_KMS_KEY_ID;
+
 public class EnvironmentProperties
 {
-    public static final String DEFAULT_GLUE_CONNECTION = "glue_connection";
-    private static final int CONNECT_TIMEOUT = 250;
-    protected static final String SECRET_NAME = "secret_name";
-    protected static final String SPILL_KMS_KEY_ID = "spill_kms_key_id";
-    protected static final String KMS_KEY_ID = "kms_key_id";
     protected static final Logger logger = LoggerFactory.getLogger(EnvironmentProperties.class);
 
     public Map<String, String> createEnvironment() throws RuntimeException

--- a/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/GcsCompositeHandler.java
+++ b/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/GcsCompositeHandler.java
@@ -19,7 +19,6 @@
  */
 package com.amazonaws.athena.connectors.gcs;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -47,9 +46,9 @@ public class GcsCompositeHandler
      */
     public GcsCompositeHandler() throws IOException, CertificateEncodingException, NoSuchAlgorithmException, KeyStoreException
     {
-        super(new GcsMetadataHandler(allocator, GlueConnectionUtils.getGlueConnection()), new GcsRecordHandler(allocator, GlueConnectionUtils.getGlueConnection()));
+        super(new GcsMetadataHandler(allocator, new GcsEnvironmentProperties().createEnvironment()), new GcsRecordHandler(allocator, new GcsEnvironmentProperties().createEnvironment()));
         installCaCertificate();
-        installGoogleCredentialsJsonFile(GlueConnectionUtils.getGlueConnection());
+        installGoogleCredentialsJsonFile(new GcsEnvironmentProperties().createEnvironment());
         setupNativeEnvironmentVariables();
     }
 }

--- a/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/GcsEnvironmentProperties.java
+++ b/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/GcsEnvironmentProperties.java
@@ -19,26 +19,22 @@
  */
 package com.amazonaws.athena.connectors.gcs;
 
-import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentProperties;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.SECRET_NAME;
+import static com.amazonaws.athena.connectors.gcs.GcsConstants.GCS_SECRET_KEY_ENV_VAR;
+
 public class GcsEnvironmentProperties extends EnvironmentProperties
 {
-    private static final String PROJECT_ID = "PROJECT_ID";
-    private static final String GCP_PROJECT_ID = "gcp_project_id";
-    private static final String SECRET_MANAGER_GCP_CREDS_NAME = "secret_manager_gcp_creds_name";
-
     @Override
     public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
     {
         Map<String, String> environment = new HashMap<>();
 
-        if (connectionProperties.containsKey(PROJECT_ID)) {
-            environment.put(GCP_PROJECT_ID, connectionProperties.get(PROJECT_ID));
-        }
-        environment.put(SECRET_MANAGER_GCP_CREDS_NAME, connectionProperties.get(SECRET_NAME));
+        environment.put(GCS_SECRET_KEY_ENV_VAR, connectionProperties.get(SECRET_NAME));
         return environment;
     }
 }

--- a/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/GcsEnvironmentProperties.java
+++ b/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/GcsEnvironmentProperties.java
@@ -1,0 +1,44 @@
+/*-
+ * #%L
+ * athena-gcs
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.gcs;
+
+import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GcsEnvironmentProperties extends EnvironmentProperties
+{
+    private static final String PROJECT_ID = "PROJECT_ID";
+    private static final String GCP_PROJECT_ID = "gcp_project_id";
+    private static final String SECRET_MANAGER_GCP_CREDS_NAME = "secret_manager_gcp_creds_name";
+
+    @Override
+    public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
+    {
+        Map<String, String> environment = new HashMap<>();
+
+        if (connectionProperties.containsKey(PROJECT_ID)) {
+            environment.put(GCP_PROJECT_ID, connectionProperties.get(PROJECT_ID));
+        }
+        environment.put(SECRET_MANAGER_GCP_CREDS_NAME, connectionProperties.get(SECRET_NAME));
+        return environment;
+    }
+}

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryCompositeHandler.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryCompositeHandler.java
@@ -20,7 +20,6 @@
  */
 package com.amazonaws.athena.connectors.google.bigquery;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -42,8 +41,8 @@ public class BigQueryCompositeHandler
     public BigQueryCompositeHandler()
             throws IOException
     {
-        super(new BigQueryMetadataHandler(GlueConnectionUtils.getGlueConnection()), new BigQueryRecordHandler(GlueConnectionUtils.getGlueConnection(), allocator));
-        installGoogleCredentialsJsonFile(GlueConnectionUtils.getGlueConnection());
+        super(new BigQueryMetadataHandler(new BigQueryEnvironmentProperties().createEnvironment()), new BigQueryRecordHandler(new BigQueryEnvironmentProperties().createEnvironment(), allocator));
+        installGoogleCredentialsJsonFile(new BigQueryEnvironmentProperties().createEnvironment());
         setupNativeEnvironmentVariables();
         logger.info("Inside BigQueryCompositeHandler()");
     }

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryEnvironmentProperties.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryEnvironmentProperties.java
@@ -19,17 +19,18 @@
  */
 package com.amazonaws.athena.connectors.google.bigquery;
 
-import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentProperties;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.PROJECT_ID;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.SECRET_NAME;
+import static com.amazonaws.athena.connectors.google.bigquery.BigQueryConstants.ENV_BIG_QUERY_CREDS_SM_ID;
+import static com.amazonaws.athena.connectors.google.bigquery.BigQueryConstants.GCP_PROJECT_ID;
+
 public class BigQueryEnvironmentProperties extends EnvironmentProperties
 {
-    private static final String PROJECT_ID = "PROJECT_ID";
-    private static final String GCP_PROJECT_ID = "gcp_project_id";
-    private static final String SECRET_MANAGER_GCP_CREDS_NAME = "secret_manager_gcp_creds_name";
-
     @Override
     public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
     {
@@ -38,7 +39,7 @@ public class BigQueryEnvironmentProperties extends EnvironmentProperties
         if (connectionProperties.containsKey(PROJECT_ID)) {
             environment.put(GCP_PROJECT_ID, connectionProperties.get(PROJECT_ID));
         }
-        environment.put(SECRET_MANAGER_GCP_CREDS_NAME, connectionProperties.get(SECRET_NAME));
+        environment.put(ENV_BIG_QUERY_CREDS_SM_ID, connectionProperties.get(SECRET_NAME));
         return environment;
     }
 }

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryEnvironmentProperties.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryEnvironmentProperties.java
@@ -1,0 +1,44 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.google.bigquery;
+
+import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BigQueryEnvironmentProperties extends EnvironmentProperties
+{
+    private static final String PROJECT_ID = "PROJECT_ID";
+    private static final String GCP_PROJECT_ID = "gcp_project_id";
+    private static final String SECRET_MANAGER_GCP_CREDS_NAME = "secret_manager_gcp_creds_name";
+
+    @Override
+    public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
+    {
+        Map<String, String> environment = new HashMap<>();
+
+        if (connectionProperties.containsKey(PROJECT_ID)) {
+            environment.put(GCP_PROJECT_ID, connectionProperties.get(PROJECT_ID));
+        }
+        environment.put(SECRET_MANAGER_GCP_CREDS_NAME, connectionProperties.get(SECRET_NAME));
+        return environment;
+    }
+}

--- a/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseCompositeHandler.java
+++ b/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseCompositeHandler.java
@@ -19,7 +19,6 @@
  */
 package com.amazonaws.athena.connectors.hbase;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -31,6 +30,6 @@ public class HbaseCompositeHandler
 {
     public HbaseCompositeHandler()
     {
-        super(new HbaseMetadataHandler(GlueConnectionUtils.getGlueConnection()), new HbaseRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new HbaseMetadataHandler(new HbaseEnvironmentProperties().createEnvironment()), new HbaseRecordHandler(new HbaseEnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseConnectionFactory.java
+++ b/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseConnectionFactory.java
@@ -19,7 +19,6 @@
  */
 package com.amazonaws.athena.connectors.hbase;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import org.apache.arrow.util.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -126,7 +125,7 @@ public class HbaseConnectionFactory
                 config.set(nextConfig.getKey(), nextConfig.getValue());
             }
 
-            Map<String, String> configOptions = GlueConnectionUtils.getGlueConnection();
+            Map<String, String> configOptions = new HbaseEnvironmentProperties().createEnvironment();
             boolean kerberosAuthEnabled = configOptions.get(KERBEROS_AUTH_ENABLED) != null && "true".equalsIgnoreCase(configOptions.get(KERBEROS_AUTH_ENABLED));
             logger.info("Kerberos Authentication Enabled: " + kerberosAuthEnabled);
             if (kerberosAuthEnabled) {

--- a/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseEnvironmentProperties.java
+++ b/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseEnvironmentProperties.java
@@ -19,22 +19,26 @@
  */
 package com.amazonaws.athena.connectors.hbase;
 
-import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentProperties;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DEFAULT_HBASE;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.HBASE_PORT;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.HOST;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.ZOOKEEPER_PORT;
+
 public class HbaseEnvironmentProperties extends EnvironmentProperties
 {
-    private static final String DEFAULT_HBASE = "default_hbase";
     @Override
     public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
     {
         Map<String, String> environment = new HashMap<>();
 
-        environment.put(DEFAULT_HBASE, connectionProperties.get("HOST")
-                + ":" + connectionProperties.get("HBASE_PORT")
-                + ":" + connectionProperties.get("ZOOKEEPER_PORT"));
+        environment.put(DEFAULT_HBASE, connectionProperties.get(HOST)
+                + ":" + connectionProperties.get(HBASE_PORT)
+                + ":" + connectionProperties.get(ZOOKEEPER_PORT));
         return environment;
     }
 }

--- a/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseEnvironmentProperties.java
+++ b/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseEnvironmentProperties.java
@@ -17,15 +17,24 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.connection;
+package com.amazonaws.athena.connectors.hbase;
 
+import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+
+import java.util.HashMap;
 import java.util.Map;
 
-public class MySqlEnvironmentProperties extends JdbcEnvironmentProperties
+public class HbaseEnvironmentProperties extends EnvironmentProperties
 {
+    private static final String DEFAULT_HBASE = "default_hbase";
     @Override
-    protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
+    public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
     {
-        return "mysql://jdbc:mysql://";
+        Map<String, String> environment = new HashMap<>();
+
+        environment.put(DEFAULT_HBASE, connectionProperties.get("HOST")
+                + ":" + connectionProperties.get("HBASE_PORT")
+                + ":" + connectionProperties.get("ZOOKEEPER_PORT"));
+        return environment;
     }
 }

--- a/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/connection/HbaseConnectionFactory.java
+++ b/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/connection/HbaseConnectionFactory.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.hbase.connection;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connectors.hbase.HbaseEnvironmentProperties;
 import org.apache.arrow.util.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -128,7 +128,7 @@ public class HbaseConnectionFactory
             config.set(nextConfig.getKey(), nextConfig.getValue());
         }
 
-        Map<String, String> configOptions = GlueConnectionUtils.getGlueConnection();
+        Map<String, String> configOptions = new HbaseEnvironmentProperties().createEnvironment();
         boolean kerberosAuthEnabled = configOptions.get(KERBEROS_AUTH_ENABLED) != null && "true".equalsIgnoreCase(configOptions.get(KERBEROS_AUTH_ENABLED));
         logger.info("Kerberos Authentication Enabled: " + kerberosAuthEnabled);
         if (kerberosAuthEnabled) {

--- a/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/integ/HbaseTableUtils.java
+++ b/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/integ/HbaseTableUtils.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.hbase.integ;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connectors.hbase.HbaseEnvironmentProperties;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
@@ -100,7 +100,7 @@ public class HbaseTableUtils
         configuration.set("hbase.client.pause", "500");
         configuration.set("zookeeper.recovery.retry", "2");
 
-        java.util.Map<String, String> configOptions = GlueConnectionUtils.getGlueConnection();
+        java.util.Map<String, String> configOptions = new HbaseEnvironmentProperties().createEnvironment();
         boolean kerberosAuthEnabled = configOptions.get(KERBEROS_AUTH_ENABLED) != null && "true".equalsIgnoreCase(configOptions.get(KERBEROS_AUTH_ENABLED));
         logger.info("Kerberos Authentication Enabled: " + kerberosAuthEnabled);
         if (kerberosAuthEnabled) {

--- a/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HiveCompositeHandler.java
+++ b/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HiveCompositeHandler.java
@@ -19,7 +19,6 @@
  */
 package com.amazonaws.athena.connectors.hortonworks;
 
-import com.amazonaws.athena.connector.lambda.connection.HortonworksEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**

--- a/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HortonworksEnvironmentProperties.java
+++ b/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HortonworksEnvironmentProperties.java
@@ -17,33 +17,17 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.connection;
+package com.amazonaws.athena.connectors.hortonworks;
+
+import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 
-public class SqlServerEnvironmentProperties extends JdbcEnvironmentProperties
+public class HortonworksEnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {
-        return "sqlserver://jdbc:sqlserver://";
-    }
-
-    @Override
-    protected String getDatabase(Map<String, String> connectionProperties)
-    {
-        return ";databaseName=" + connectionProperties.get(DATABASE);
-    }
-
-    @Override
-    protected String getJdbcParametersSeparator()
-    {
-        return ";";
-    }
-
-    @Override
-    protected String getDelimiter()
-    {
-        return ";";
+        return "hive://jdbc:hive2://";
     }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/JdbcEnvironmentProperties.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/JdbcEnvironmentProperties.java
@@ -19,25 +19,28 @@
  */
 package com.amazonaws.athena.connectors.jdbc;
 
-import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentProperties;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DATABASE;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DEFAULT;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.HOST;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.JDBC_PARAMS;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.PORT;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.SECRET_NAME;
+
 public abstract class JdbcEnvironmentProperties extends EnvironmentProperties
 {
-    protected static final String DEFAULT = "default";
-    protected static final String JDBC_PARAMS = "JDBC_PARAMS";
-    protected static final String DATABASE = "DATABASE";
-
     @Override
     public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
     {
         HashMap<String, String> environment = new HashMap<>();
 
         // now construct jdbc string
-        String connectionString = getConnectionStringPrefix(connectionProperties) + connectionProperties.get("HOST")
-                + ":" + connectionProperties.get("PORT") + getDatabase(connectionProperties) + getJdbcParameters(connectionProperties);
+        String connectionString = getConnectionStringPrefix(connectionProperties) + connectionProperties.get(HOST)
+                + ":" + connectionProperties.get(PORT) + getDatabase(connectionProperties) + getJdbcParameters(connectionProperties);
 
         environment.put(DEFAULT, connectionString);
         return environment;

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/JdbcEnvironmentProperties.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/JdbcEnvironmentProperties.java
@@ -17,7 +17,9 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.connection;
+package com.amazonaws.athena.connectors.jdbc;
+
+import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,7 +39,6 @@ public abstract class JdbcEnvironmentProperties extends EnvironmentProperties
         String connectionString = getConnectionStringPrefix(connectionProperties) + connectionProperties.get("HOST")
                 + ":" + connectionProperties.get("PORT") + getDatabase(connectionProperties) + getJdbcParameters(connectionProperties);
 
-        logger.debug("Constructed connection string: {}", connectionString);
         environment.put(DEFAULT, connectionString);
         return environment;
     }

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskCompositeHandler.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskCompositeHandler.java
@@ -19,7 +19,6 @@
  */
 package com.amazonaws.athena.connectors.msk;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 public class AmazonMskCompositeHandler
@@ -27,6 +26,6 @@ public class AmazonMskCompositeHandler
 {
     public AmazonMskCompositeHandler() throws Exception
     {
-        super(new AmazonMskMetadataHandler(GlueConnectionUtils.getGlueConnection()), new AmazonMskRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new AmazonMskMetadataHandler(new AmazonMskEnvironmentProperties().createEnvironment()), new AmazonMskRecordHandler(new AmazonMskEnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskEnvironmentProperties.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskEnvironmentProperties.java
@@ -19,20 +19,23 @@
  */
 package com.amazonaws.athena.connectors.msk;
 
-import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentProperties;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.CUSTOM_AUTH_TYPE;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.GLUE_CERTIFICATES_S3_REFERENCE;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.HOST;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.PORT;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.SECRET_NAME;
+import static com.amazonaws.athena.connectors.msk.AmazonMskConstants.AUTH_TYPE;
+import static com.amazonaws.athena.connectors.msk.AmazonMskConstants.CERTIFICATES_S3_REFERENCE;
+import static com.amazonaws.athena.connectors.msk.AmazonMskConstants.ENV_KAFKA_ENDPOINT;
+import static com.amazonaws.athena.connectors.msk.AmazonMskConstants.SECRET_MANAGER_MSK_CREDS_NAME;
+
 public class AmazonMskEnvironmentProperties extends EnvironmentProperties
 {
-    private static final String AUTH_TYPE = "auth_type";
-    private static final String CUSTOM_AUTH_TYPE = "CUSTOM_AUTH_TYPE";
-    private static final String CERTIFICATES_S3_REFERENCE = "certificates_s3_reference";
-    private static final String GLUE_CERTIFICATES_S3_REFERENCE = "CERTIFICATE_S3_REFERENCE";
-    private static final String SECRETS_MANAGER_SECRET = "secrets_manager_secret";
-    private static final String KAFKA_ENDPOINT = "kafka_endpoint";
-
     @Override
     public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
     {
@@ -40,8 +43,8 @@ public class AmazonMskEnvironmentProperties extends EnvironmentProperties
 
         environment.put(AUTH_TYPE, connectionProperties.get(CUSTOM_AUTH_TYPE));
         environment.put(CERTIFICATES_S3_REFERENCE, connectionProperties.getOrDefault(GLUE_CERTIFICATES_S3_REFERENCE, ""));
-        environment.put(SECRETS_MANAGER_SECRET, connectionProperties.getOrDefault(SECRET_NAME, ""));
-        environment.put(KAFKA_ENDPOINT, connectionProperties.get("HOST") + ":" + connectionProperties.get("PORT"));
+        environment.put(SECRET_MANAGER_MSK_CREDS_NAME, connectionProperties.getOrDefault(SECRET_NAME, ""));
+        environment.put(ENV_KAFKA_ENDPOINT, connectionProperties.get(HOST) + ":" + connectionProperties.get(PORT));
         return environment;
     }
 }

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskEnvironmentProperties.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskEnvironmentProperties.java
@@ -1,0 +1,47 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.msk;
+
+import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AmazonMskEnvironmentProperties extends EnvironmentProperties
+{
+    private static final String AUTH_TYPE = "auth_type";
+    private static final String CUSTOM_AUTH_TYPE = "CUSTOM_AUTH_TYPE";
+    private static final String CERTIFICATES_S3_REFERENCE = "certificates_s3_reference";
+    private static final String GLUE_CERTIFICATES_S3_REFERENCE = "CERTIFICATE_S3_REFERENCE";
+    private static final String SECRETS_MANAGER_SECRET = "secrets_manager_secret";
+    private static final String KAFKA_ENDPOINT = "kafka_endpoint";
+
+    @Override
+    public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
+    {
+        Map<String, String> environment = new HashMap<>();
+
+        environment.put(AUTH_TYPE, connectionProperties.get(CUSTOM_AUTH_TYPE));
+        environment.put(CERTIFICATES_S3_REFERENCE, connectionProperties.getOrDefault(GLUE_CERTIFICATES_S3_REFERENCE, ""));
+        environment.put(SECRETS_MANAGER_SECRET, connectionProperties.getOrDefault(SECRET_NAME, ""));
+        environment.put(KAFKA_ENDPOINT, connectionProperties.get("HOST") + ":" + connectionProperties.get("PORT"));
+        return environment;
+    }
+}

--- a/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlCompositeHandler.java
+++ b/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlCompositeHandler.java
@@ -19,7 +19,6 @@
  */
 package com.amazonaws.athena.connectors.mysql;
 
-import com.amazonaws.athena.connector.lambda.connection.MySqlEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**

--- a/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlEnvironmentProperties.java
+++ b/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlEnvironmentProperties.java
@@ -17,27 +17,17 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.connection;
+package com.amazonaws.athena.connectors.mysql;
+
+import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 
-public class TeradataEnvironmentProperties extends JdbcEnvironmentProperties
+public class MySqlEnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {
-        return "teradata://jdbc:teradata://";
-    }
-
-    @Override
-    protected String getDatabase(Map<String, String> connectionProperties)
-    {
-        return "/TMODE=ANSI,CHARSET=UTF8,DATABASE=" + connectionProperties.get(DATABASE);
-    }
-
-    @Override
-    protected String getJdbcParametersSeparator()
-    {
-        return ",";
+        return "mysql://jdbc:mysql://";
     }
 }

--- a/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/Constants.java
+++ b/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/Constants.java
@@ -32,6 +32,7 @@ public class Constants
    public static final String CFG_PORT = "neptune_port";
    public static final String CFG_IAM = "iam_enabled";
    public static final String CFG_REGION = "AWS_REGION";
+   public static final String CFG_ClUSTER_RES_ID = "neptune_cluster_res_id";
     
    public static final String SCHEMA_QUERY = "query";
    public static final String SCHEMA_CASE_INSEN = "enable_caseinsensitivematch";

--- a/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/NeptuneCompositeHandler.java
+++ b/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/NeptuneCompositeHandler.java
@@ -19,7 +19,6 @@
  */
 package com.amazonaws.athena.connectors.neptune;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -31,6 +30,6 @@ public class NeptuneCompositeHandler
 {
     public NeptuneCompositeHandler()
     {
-        super(new NeptuneMetadataHandler(GlueConnectionUtils.getGlueConnection()), new NeptuneRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new NeptuneMetadataHandler(new NeptuneEnvironmentProperties().createEnvironment()), new NeptuneRecordHandler(new NeptuneEnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/NeptuneEnvironmentProperties.java
+++ b/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/NeptuneEnvironmentProperties.java
@@ -19,29 +19,31 @@
  */
 package com.amazonaws.athena.connectors.neptune;
 
-import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentProperties;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.CLUSTER_RES_ID;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.GRAPH_TYPE;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.HOST;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.PORT;
+import static com.amazonaws.athena.connectors.neptune.Constants.CFG_ClUSTER_RES_ID;
+import static com.amazonaws.athena.connectors.neptune.Constants.CFG_ENDPOINT;
+import static com.amazonaws.athena.connectors.neptune.Constants.CFG_GRAPH_TYPE;
+import static com.amazonaws.athena.connectors.neptune.Constants.CFG_PORT;
+
 public class NeptuneEnvironmentProperties extends EnvironmentProperties
 {
-    private static final String NEPTUNE_ENDPOINT = "neptune_endpoint";
-    private static final String NEPTUNE_PORT = "neptune_port";
-    private static final String NEPTUNE_CLUSTER_RES_ID = "neptune_cluster_res_id";
-    private static final String CLUSTER_RES_ID = "CLUSTER_RESOURCE_ID";
-    private static final String NEPTUNE_GRAPHTYPE = "neptune_graphtype";
-    private static final String GRAPH_TYPE = "GRAPH_TYPE";
-
     @Override
     public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
     {
         Map<String, String> environment = new HashMap<>();
 
-        environment.put(NEPTUNE_ENDPOINT, connectionProperties.get("HOST"));
-        environment.put(NEPTUNE_PORT, connectionProperties.get("PORT"));
-        environment.put(NEPTUNE_CLUSTER_RES_ID, environment.get(CLUSTER_RES_ID));
-        environment.put(NEPTUNE_GRAPHTYPE, environment.get(GRAPH_TYPE));
+        environment.put(CFG_ENDPOINT, connectionProperties.get(HOST));
+        environment.put(CFG_PORT, connectionProperties.get(PORT));
+        environment.put(CFG_ClUSTER_RES_ID, environment.get(CLUSTER_RES_ID));
+        environment.put(CFG_GRAPH_TYPE, environment.get(GRAPH_TYPE));
         return environment;
     }
 }

--- a/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/NeptuneEnvironmentProperties.java
+++ b/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/NeptuneEnvironmentProperties.java
@@ -1,0 +1,47 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.neptune;
+
+import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class NeptuneEnvironmentProperties extends EnvironmentProperties
+{
+    private static final String NEPTUNE_ENDPOINT = "neptune_endpoint";
+    private static final String NEPTUNE_PORT = "neptune_port";
+    private static final String NEPTUNE_CLUSTER_RES_ID = "neptune_cluster_res_id";
+    private static final String CLUSTER_RES_ID = "CLUSTER_RESOURCE_ID";
+    private static final String NEPTUNE_GRAPHTYPE = "neptune_graphtype";
+    private static final String GRAPH_TYPE = "GRAPH_TYPE";
+
+    @Override
+    public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
+    {
+        Map<String, String> environment = new HashMap<>();
+
+        environment.put(NEPTUNE_ENDPOINT, connectionProperties.get("HOST"));
+        environment.put(NEPTUNE_PORT, connectionProperties.get("PORT"));
+        environment.put(NEPTUNE_CLUSTER_RES_ID, environment.get(CLUSTER_RES_ID));
+        environment.put(NEPTUNE_GRAPHTYPE, environment.get(GRAPH_TYPE));
+        return environment;
+    }
+}

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCompositeHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCompositeHandler.java
@@ -20,7 +20,6 @@
  */
 package com.amazonaws.athena.connectors.oracle;
 
-import com.amazonaws.athena.connector.lambda.connection.OracleEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleEnvironmentProperties.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleEnvironmentProperties.java
@@ -23,6 +23,9 @@ import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DATABASE;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.SECRET_NAME;
+
 public class OracleEnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleEnvironmentProperties.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleEnvironmentProperties.java
@@ -17,7 +17,9 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.connection;
+package com.amazonaws.athena.connectors.oracle;
+
+import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 

--- a/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlCompositeHandler.java
+++ b/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlCompositeHandler.java
@@ -19,7 +19,6 @@
  */
 package com.amazonaws.athena.connectors.postgresql;
 
-import com.amazonaws.athena.connector.lambda.connection.PostGreSqlEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**

--- a/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlEnvironmentProperties.java
+++ b/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlEnvironmentProperties.java
@@ -17,15 +17,17 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.connection;
+package com.amazonaws.athena.connectors.postgresql;
+
+import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 
-public class DataLakeGen2EnvironmentProperties extends SqlServerEnvironmentProperties
+public class PostGreSqlEnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {
-        return "datalakegentwo://jdbc:sqlserver://";
+        return "postgres://jdbc:postgresql://";
     }
 }

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisCompositeHandler.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.redis;
 
-import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisCompositeHandler.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.redis;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -31,6 +31,6 @@ public class RedisCompositeHandler
 {
     public RedisCompositeHandler()
     {
-        super(new RedisMetadataHandler(GlueConnectionUtils.getGlueConnection()), new RedisRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new RedisMetadataHandler(new EnvironmentProperties().createEnvironment()), new RedisRecordHandler(new EnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaCompositeHandler.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaCompositeHandler.java
@@ -22,7 +22,6 @@
 
 package com.amazonaws.athena.connectors.saphana;
 
-import com.amazonaws.athena.connector.lambda.connection.SaphanaEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**

--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaEnvironmentProperties.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaEnvironmentProperties.java
@@ -17,15 +17,23 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.connection;
+package com.amazonaws.athena.connectors.saphana;
+
+import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 
-public class HortonworksEnvironmentProperties extends JdbcEnvironmentProperties
+public class SaphanaEnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {
-        return "hive://jdbc:hive2://";
+        return "saphana://jdbc:sap://";
+    }
+
+    @Override
+    protected String getDatabase(Map<String, String> connectionProperties)
+    {
+        return "/";
     }
 }

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeCompositeHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeCompositeHandler.java
@@ -22,7 +22,6 @@
 
 package com.amazonaws.athena.connectors.snowflake;
 
-import com.amazonaws.athena.connector.lambda.connection.SnowflakeEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeEnvironmentProperties.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeEnvironmentProperties.java
@@ -23,10 +23,12 @@ import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DATABASE;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.SCHEMA;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.WAREHOUSE;
+
 public class SnowflakeEnvironmentProperties extends JdbcEnvironmentProperties
 {
-    private static final String WAREHOUSE = "WAREHOUSE";
-    private static final String SCHEMA = "SCHEMA";
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeEnvironmentProperties.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeEnvironmentProperties.java
@@ -17,7 +17,9 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.connection;
+package com.amazonaws.athena.connectors.snowflake;
+
+import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerCompositeHandler.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerCompositeHandler.java
@@ -19,7 +19,6 @@
  */
 package com.amazonaws.athena.connectors.sqlserver;
 
-import com.amazonaws.athena.connector.lambda.connection.SqlServerEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 public class SqlServerCompositeHandler extends CompositeHandler

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerEnvironmentProperties.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerEnvironmentProperties.java
@@ -23,6 +23,8 @@ import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DATABASE;
+
 public class SqlServerEnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerEnvironmentProperties.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerEnvironmentProperties.java
@@ -17,15 +17,35 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.connection;
+package com.amazonaws.athena.connectors.sqlserver;
+
+import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 
-public class SynapseEnvironmentProperties extends SqlServerEnvironmentProperties
+public class SqlServerEnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {
-        return "synapse://jdbc:synapse://";
+        return "sqlserver://jdbc:sqlserver://";
+    }
+
+    @Override
+    protected String getDatabase(Map<String, String> connectionProperties)
+    {
+        return ";databaseName=" + connectionProperties.get(DATABASE);
+    }
+
+    @Override
+    protected String getJdbcParametersSeparator()
+    {
+        return ";";
+    }
+
+    @Override
+    protected String getDelimiter()
+    {
+        return ";";
     }
 }

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseCompositeHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseCompositeHandler.java
@@ -19,7 +19,6 @@
  */
 package com.amazonaws.athena.connectors.synapse;
 
-import com.amazonaws.athena.connector.lambda.connection.SynapseEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 public class SynapseCompositeHandler extends CompositeHandler

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseEnvironmentProperties.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseEnvironmentProperties.java
@@ -23,6 +23,8 @@ import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DATABASE;
+
 public class SynapseEnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseEnvironmentProperties.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseEnvironmentProperties.java
@@ -17,15 +17,35 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.connection;
+package com.amazonaws.athena.connectors.synapse;
+
+import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 
-public class PostGreSqlEnvironmentProperties extends JdbcEnvironmentProperties
+public class SynapseEnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {
-        return "postgres://jdbc:postgresql://";
+        return "synapse://jdbc:synapse://";
+    }
+
+    @Override
+    protected String getDatabase(Map<String, String> connectionProperties)
+    {
+        return ";databaseName=" + connectionProperties.get(DATABASE);
+    }
+
+    @Override
+    protected String getJdbcParametersSeparator()
+    {
+        return ";";
+    }
+
+    @Override
+    protected String getDelimiter()
+    {
+        return ";";
     }
 }

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataCompositeHandler.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataCompositeHandler.java
@@ -21,7 +21,6 @@
 
 package com.amazonaws.athena.connectors.teradata;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -35,6 +34,6 @@ public class TeradataCompositeHandler
 {
     public TeradataCompositeHandler()
     {
-        super(new TeradataMetadataHandler(GlueConnectionUtils.getGlueConnection()), new TeradataRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new TeradataMetadataHandler(new TeradataEnvironmentProperties().createEnvironment()), new TeradataRecordHandler(new TeradataEnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataEnvironmentProperties.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataEnvironmentProperties.java
@@ -23,6 +23,8 @@ import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DATABASE;
+
 public class TeradataEnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataEnvironmentProperties.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataEnvironmentProperties.java
@@ -1,0 +1,45 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.teradata;
+
+import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
+
+import java.util.Map;
+
+public class TeradataEnvironmentProperties extends JdbcEnvironmentProperties
+{
+    @Override
+    protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
+    {
+        return "teradata://jdbc:teradata://";
+    }
+
+    @Override
+    protected String getDatabase(Map<String, String> connectionProperties)
+    {
+        return "/TMODE=ANSI,CHARSET=UTF8,DATABASE=" + connectionProperties.get(DATABASE);
+    }
+
+    @Override
+    protected String getJdbcParametersSeparator()
+    {
+        return ",";
+    }
+}

--- a/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamCompositeHandler.java
+++ b/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.timestream;
 
-import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 public class TimestreamCompositeHandler

--- a/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamCompositeHandler.java
+++ b/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.timestream;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 public class TimestreamCompositeHandler
@@ -27,6 +27,6 @@ public class TimestreamCompositeHandler
 {
     public TimestreamCompositeHandler()
     {
-        super(new TimestreamMetadataHandler(GlueConnectionUtils.getGlueConnection()), new TimestreamRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new TimestreamMetadataHandler(new EnvironmentProperties().createEnvironment()), new TimestreamRecordHandler(new EnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-tpcds/src/main/java/com/amazonaws/athena/connectors/tpcds/TPCDSCompositeHandler.java
+++ b/athena-tpcds/src/main/java/com/amazonaws/athena/connectors/tpcds/TPCDSCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.tpcds;
 
-import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 public class TPCDSCompositeHandler

--- a/athena-tpcds/src/main/java/com/amazonaws/athena/connectors/tpcds/TPCDSCompositeHandler.java
+++ b/athena-tpcds/src/main/java/com/amazonaws/athena/connectors/tpcds/TPCDSCompositeHandler.java
@@ -19,7 +19,7 @@
  */
 package com.amazonaws.athena.connectors.tpcds;
 
-import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
+import com.amazonaws.athena.connector.lambda.EnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 public class TPCDSCompositeHandler
@@ -27,6 +27,6 @@ public class TPCDSCompositeHandler
 {
     public TPCDSCompositeHandler()
     {
-        super(new TPCDSMetadataHandler(GlueConnectionUtils.getGlueConnection()), new TPCDSRecordHandler(GlueConnectionUtils.getGlueConnection()));
+        super(new TPCDSMetadataHandler(new EnvironmentProperties().createEnvironment()), new TPCDSRecordHandler(new EnvironmentProperties().createEnvironment()));
     }
 }

--- a/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaCompositeHandler.java
+++ b/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaCompositeHandler.java
@@ -19,7 +19,6 @@
  */
 package com.amazonaws.athena.connectors.vertica;
 
-import com.amazonaws.athena.connector.lambda.connection.VerticaEnvironmentProperties;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 import java.io.IOException;

--- a/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaEnvironmentProperties.java
+++ b/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaEnvironmentProperties.java
@@ -17,27 +17,17 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.connection;
+package com.amazonaws.athena.connectors.vertica;
+
+import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
 import java.util.Map;
 
-public class Db2EnvironmentProperties extends JdbcEnvironmentProperties
+public class VerticaEnvironmentProperties extends JdbcEnvironmentProperties
 {
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {
-        return "dbtwo://jdbc:db2://";
-    }
-
-    @Override
-    protected String getDatabase(Map<String, String> connectionProperties)
-    {
-        return ":" + connectionProperties.get(DATABASE);
-    }
-
-    @Override
-    protected String getDelimiter()
-    {
-        return ";";
+        return "vertica://jdbc:vertica://";
     }
 }


### PR DESCRIPTION
Refactor EnvironmentProperties so federation-sdk has no information on connector-specific properties