### PR TITLE
update connectors with mux handlers to use normal in connections yaml

### DIFF
--- a/athena-cloudera-hive/Dockerfile
+++ b/athena-cloudera-hive/Dockerfile
@@ -5,5 +5,5 @@ COPY target/athena-cloudera-hive-2022.47.1.jar ${LAMBDA_TASK_ROOT}
 # Unpack the jar
 RUN jar xf athena-cloudera-hive-2022.47.1.jar
 
-# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
-CMD [ "com.amazonaws.athena.connectors.cloudera.HiveMuxCompositeHandler" ]
+# Command can be overwritten by providing a different command in the template directly.
+# No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-cloudera-hive/athena-cloudera-hive-connection.yaml
+++ b/athena-cloudera-hive/athena-cloudera-hive-connection.yaml
@@ -54,6 +54,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-cloudera-hive:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.cloudera.HiveCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with Cloudera Hive using JDBC"
       Timeout: 900
       MemorySize: 3008

--- a/athena-cloudera-hive/athena-cloudera-hive.yaml
+++ b/athena-cloudera-hive/athena-cloudera-hive.yaml
@@ -67,6 +67,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-cloudera-hive:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.cloudera.HiveMuxCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with Coludera Hive using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-cloudera-impala/Dockerfile
+++ b/athena-cloudera-impala/Dockerfile
@@ -5,5 +5,5 @@ COPY target/athena-cloudera-impala-2022.47.1.jar ${LAMBDA_TASK_ROOT}
 # Unpack the jar
 RUN jar xf athena-cloudera-impala-2022.47.1.jar
 
-# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
-CMD [ "com.amazonaws.athena.connectors.cloudera.ImpalaMuxCompositeHandler" ]
+# Command can be overwritten by providing a different command in the template directly.
+# No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-cloudera-impala/athena-cloudera-impala-connection.yaml
+++ b/athena-cloudera-impala/athena-cloudera-impala-connection.yaml
@@ -54,6 +54,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-cloudera-impala:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.cloudera.ImpalaCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with Cloudera Impala using JDBC"
       Timeout: 900
       MemorySize: 3008

--- a/athena-cloudera-impala/athena-cloudera-impala.yaml
+++ b/athena-cloudera-impala/athena-cloudera-impala.yaml
@@ -72,6 +72,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-cloudera-impala:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.cloudera.ImpalaMuxCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with Cloudera Impala using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-datalakegen2/Dockerfile
+++ b/athena-datalakegen2/Dockerfile
@@ -5,5 +5,5 @@ COPY target/athena-datalakegen2-2022.47.1.jar ${LAMBDA_TASK_ROOT}
 # Unpack the jar
 RUN jar xf athena-datalakegen2-2022.47.1.jar
 
-# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
-CMD [ "com.amazonaws.athena.connectors.datalakegen2.DataLakeGen2MuxCompositeHandler" ]
+# Command can be overwritten by providing a different command in the template directly.
+# No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-datalakegen2/athena-datalakegen2-connection.yaml
+++ b/athena-datalakegen2/athena-datalakegen2-connection.yaml
@@ -62,6 +62,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-datalakegen2:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.datalakegen2.DataLakeGen2CompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with DataLake Gen2 using JDBC"
       Timeout: !Ref 900
       MemorySize: !Ref 3008

--- a/athena-datalakegen2/athena-datalakegen2.yaml
+++ b/athena-datalakegen2/athena-datalakegen2.yaml
@@ -73,6 +73,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-datalakegen2:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.datalakegen2.DataLakeGen2MuxCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with DataLake Gen2 using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-db2-as400/Dockerfile
+++ b/athena-db2-as400/Dockerfile
@@ -5,5 +5,5 @@ COPY target/athena-db2-as400-2022.47.1.jar ${LAMBDA_TASK_ROOT}
 # Unpack the jar
 RUN jar xf athena-db2-as400-2022.47.1.jar
 
-# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
-CMD [ "com.amazonaws.athena.connectors.db2as400.Db2As400MuxCompositeHandler" ]
+# Command can be overwritten by providing a different command in the template directly.
+# No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-db2-as400/athena-db2-as400-connection.yaml
+++ b/athena-db2-as400/athena-db2-as400-connection.yaml
@@ -63,6 +63,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-db2-as400:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.db2as400.Db2As400CompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with DB2 on iSeries (AS400) using JDBC"
       Timeout: 900
       MemorySize: 3008

--- a/athena-db2-as400/athena-db2-as400.yaml
+++ b/athena-db2-as400/athena-db2-as400.yaml
@@ -74,6 +74,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-db2-as400:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.db2as400.Db2As400MuxCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with DB2 on iSeries (AS400) using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-db2/Dockerfile
+++ b/athena-db2/Dockerfile
@@ -5,5 +5,5 @@ COPY target/athena-db2-2022.47.1.jar ${LAMBDA_TASK_ROOT}
 # Unpack the jar
 RUN jar xf athena-db2-2022.47.1.jar
 
-# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
-CMD [ "com.amazonaws.athena.connectors.db2.Db2MuxCompositeHandler" ]
+# Command can be overwritten by providing a different command in the template directly.
+# No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-db2/athena-db2-connection.yaml
+++ b/athena-db2/athena-db2-connection.yaml
@@ -63,6 +63,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-db2:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.db2.Db2CompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with DB2 using JDBC"
       Timeout: 900
       MemorySize: 3008

--- a/athena-db2/athena-db2.yaml
+++ b/athena-db2/athena-db2.yaml
@@ -74,6 +74,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-db2:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.db2.Db2MuxCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with DB2 using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-hortonworks-hive/Dockerfile
+++ b/athena-hortonworks-hive/Dockerfile
@@ -5,5 +5,5 @@ COPY target/athena-hortonworks-hive-2022.47.1.jar ${LAMBDA_TASK_ROOT}
 # Unpack the jar
 RUN jar xf athena-hortonworks-hive-2022.47.1.jar
 
-# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
-CMD [ "com.amazonaws.athena.connectors.hortonworks.HiveMuxCompositeHandler" ]
+# Command can be overwritten by providing a different command in the template directly.
+# No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-hortonworks-hive/athena-hortonworks-hive-connection.yaml
+++ b/athena-hortonworks-hive/athena-hortonworks-hive-connection.yaml
@@ -60,6 +60,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-hortonworks-hive:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.hortonworks.HiveCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with Hortonworks Hive using JDBC"
       Timeout: 900
       MemorySize: 3008

--- a/athena-hortonworks-hive/athena-hortonworks-hive.yaml
+++ b/athena-hortonworks-hive/athena-hortonworks-hive.yaml
@@ -71,6 +71,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-hortonworks-hive:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.hortonworks.HiveMuxCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with Hortonworks Hive using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-mysql/Dockerfile
+++ b/athena-mysql/Dockerfile
@@ -5,5 +5,5 @@ COPY target/athena-mysql-2022.47.1.jar ${LAMBDA_TASK_ROOT}
 # Unpack the jar
 RUN jar xf athena-mysql-2022.47.1.jar
 
-# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
-CMD [ "com.amazonaws.athena.connectors.mysql.MySqlMuxCompositeHandler" ]
+# Command can be overwritten by providing a different command in the template directly.
+# No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-mysql/athena-mysql-connection.yaml
+++ b/athena-mysql/athena-mysql-connection.yaml
@@ -56,6 +56,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-mysql:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.mysql.MySqlMuxCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with MySQL using JDBC"
       Timeout: 900
       MemorySize: 3008

--- a/athena-mysql/athena-mysql-connection.yaml
+++ b/athena-mysql/athena-mysql-connection.yaml
@@ -57,7 +57,7 @@ Resources:
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-mysql:2022.47.1'
       ImageConfig:
-        Command: [ "com.amazonaws.athena.connectors.mysql.MySqlMuxCompositeHandler" ]
+        Command: [ "com.amazonaws.athena.connectors.mysql.MySqlCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with MySQL using JDBC"
       Timeout: 900
       MemorySize: 3008

--- a/athena-mysql/athena-mysql.yaml
+++ b/athena-mysql/athena-mysql.yaml
@@ -72,6 +72,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-mysql:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.mysql.MySqlMuxCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with MySQL using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-oracle/Dockerfile
+++ b/athena-oracle/Dockerfile
@@ -5,5 +5,5 @@ COPY target/athena-oracle-2022.47.1.jar ${LAMBDA_TASK_ROOT}
 # Unpack the jar
 RUN jar xf athena-oracle-2022.47.1.jar
 
-# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
-CMD [ "com.amazonaws.athena.connectors.oracle.OracleMuxCompositeHandler" ]
+# Command can be overwritten by providing a different command in the template directly.
+# No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-oracle/athena-oracle-connection.yaml
+++ b/athena-oracle/athena-oracle-connection.yaml
@@ -57,6 +57,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-oracle:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.oracle.OracleCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with ORACLE using JDBC"
       Timeout: 900
       MemorySize: 3008

--- a/athena-oracle/athena-oracle.yaml
+++ b/athena-oracle/athena-oracle.yaml
@@ -84,6 +84,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-oracle:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.oracle.OracleMuxCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with ORACLE using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-redshift/Dockerfile
+++ b/athena-redshift/Dockerfile
@@ -5,5 +5,5 @@ COPY target/athena-redshift-2022.47.1.jar ${LAMBDA_TASK_ROOT}
 # Unpack the jar
 RUN jar xf athena-redshift-2022.47.1.jar
 
-# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
-CMD [ "com.amazonaws.athena.connectors.redshift.RedshiftMuxCompositeHandler" ]
+# Command can be overwritten by providing a different command in the template directly.
+# No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-redshift/athena-redshift-connection.yaml
+++ b/athena-redshift/athena-redshift-connection.yaml
@@ -54,6 +54,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-redshift:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.redshift.RedshiftCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with Redshift using JDBC"
       Timeout: 900
       MemorySize: 3008

--- a/athena-redshift/athena-redshift.yaml
+++ b/athena-redshift/athena-redshift.yaml
@@ -81,6 +81,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-redshift:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.redshift.RedshiftMuxCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with Redshift using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-saphana/Dockerfile
+++ b/athena-saphana/Dockerfile
@@ -5,5 +5,5 @@ COPY target/athena-saphana.zip ${LAMBDA_TASK_ROOT}
 # Unpack the jar
 RUN jar xf athena-saphana.zip
 
-# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
-CMD [ "com.amazonaws.athena.connectors.saphana.SaphanaMuxCompositeHandler" ]
+# Command can be overwritten by providing a different command in the template directly.
+# No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-saphana/athena-saphana-connection.yaml
+++ b/athena-saphana/athena-saphana-connection.yaml
@@ -60,6 +60,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-saphana:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.saphana.SaphanaCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with Teradata using JDBC"
       Timeout: 900
       MemorySize: 3008

--- a/athena-saphana/athena-saphana.yaml
+++ b/athena-saphana/athena-saphana.yaml
@@ -71,6 +71,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-saphana:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.saphana.SaphanaMuxCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with Teradata using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-snowflake/Dockerfile
+++ b/athena-snowflake/Dockerfile
@@ -5,5 +5,5 @@ COPY target/athena-snowflake.zip ${LAMBDA_TASK_ROOT}
 # Unpack the jar
 RUN jar xf athena-snowflake.zip
 
-# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
-CMD [ "com.amazonaws.athena.connectors.snowflake.SnowflakeMuxCompositeHandler" ]
+# Command can be overwritten by providing a different command in the template directly.
+# No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-snowflake/athena-snowflake-connection.yaml
+++ b/athena-snowflake/athena-snowflake-connection.yaml
@@ -60,6 +60,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-snowflake:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.snowflake.SnowflakeCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with Snowflake using JDBC"
       Timeout: 900
       MemorySize: 3008

--- a/athena-snowflake/athena-snowflake.yaml
+++ b/athena-snowflake/athena-snowflake.yaml
@@ -71,6 +71,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-snowflake:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.snowflake.SnowflakeMuxCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with Snowflake using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-sqlserver/Dockerfile
+++ b/athena-sqlserver/Dockerfile
@@ -5,5 +5,5 @@ COPY target/athena-sqlserver-2022.47.1.jar ${LAMBDA_TASK_ROOT}
 # Unpack the jar
 RUN jar xf athena-sqlserver-2022.47.1.jar
 
-# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
-CMD [ "com.amazonaws.athena.connectors.sqlserver.SqlServerMuxCompositeHandler" ]
+# Command can be overwritten by providing a different command in the template directly.
+# No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-sqlserver/athena-sqlserver-connection.yaml
+++ b/athena-sqlserver/athena-sqlserver-connection.yaml
@@ -60,6 +60,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-sqlserver:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.sqlserver.SqlServerCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with SQLSERVER using JDBC"
       Timeout: 900
       MemorySize: 3008

--- a/athena-sqlserver/athena-sqlserver.yaml
+++ b/athena-sqlserver/athena-sqlserver.yaml
@@ -78,6 +78,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-sqlserver:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.sqlserver.SqlServerMuxCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with SQLSERVER using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-synapse/Dockerfile
+++ b/athena-synapse/Dockerfile
@@ -5,5 +5,5 @@ COPY target/athena-synapse-2022.47.1.jar ${LAMBDA_TASK_ROOT}
 # Unpack the jar
 RUN jar xf athena-synapse-2022.47.1.jar
 
-# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
-CMD [ "com.amazonaws.athena.connectors.synapse.SynapseMuxCompositeHandler" ]
+# Command can be overwritten by providing a different command in the template directly.
+# No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-synapse/athena-synapse-connection.yaml
+++ b/athena-synapse/athena-synapse-connection.yaml
@@ -62,6 +62,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-synapse:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.synapse.SynapseCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with SYNPASE using JDBC"
       Timeout: 900
       MemorySize: 3008

--- a/athena-synapse/athena-synapse.yaml
+++ b/athena-synapse/athena-synapse.yaml
@@ -80,6 +80,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-synapse:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.synapse.SynapseMuxCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with SYNPASE using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-teradata/Dockerfile
+++ b/athena-teradata/Dockerfile
@@ -5,5 +5,5 @@ COPY target/athena-teradata-2022.47.1.jar ${LAMBDA_TASK_ROOT}
 # Unpack the jar
 RUN jar xf athena-teradata-2022.47.1.jar
 
-# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
-CMD [ "com.amazonaws.athena.connectors.teradata.TeradataMuxCompositeHandler" ]
+# Command can be overwritten by providing a different command in the template directly.
+# No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-teradata/athena-teradata-connection.yaml
+++ b/athena-teradata/athena-teradata-connection.yaml
@@ -58,6 +58,8 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-teradata:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.teradata.TeradataCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with Teradata using JDBC"
       Timeout: 900
       MemorySize: 3008

--- a/athena-teradata/athena-teradata.yaml
+++ b/athena-teradata/athena-teradata.yaml
@@ -81,6 +81,8 @@ Resources:
         - !Ref LambdaJDBCLayername
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-teradata:2022.47.1'
+      ImageConfig:
+        Command: [ "com.amazonaws.athena.connectors.teradata.TeradataMuxCompositeHandler" ]
       Description: "Enables Amazon Athena to communicate with Teradata using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory


### PR DESCRIPTION
Change all connectors that currently use the MuxCompositeHandler as the entrypoint to use the ImageConfig property to use the MuxCompositeHandler in the legacy and the CompositeHandler in the connections yaml.